### PR TITLE
feat: 支出記録の編集機能を追加

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -47,7 +47,7 @@ func setupMiddleware(e *echo.Echo, appConfig *config.AppConfig) {
 	e.Use(echomiddleware.Recover())
 	e.Use(echomiddleware.CORSWithConfig(echomiddleware.CORSConfig{
 		AllowOrigins:     appConfig.AllowOrigins,
-		AllowMethods:     []string{http.MethodGet, http.MethodPost, http.MethodDelete},
+		AllowMethods:     []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete},
 		AllowCredentials: true,
 	}))
 	e.Use(middleware.ErrorHandler())
@@ -73,6 +73,7 @@ func setupRoutes(e *echo.Echo, deps *setup.Dependencies) {
 	houseHold.POST("/:householdID/category", deps.HouseHoldHandler.AddHouseHoldCategory)
 	houseHold.GET("/:householdID/shopping/record", deps.HouseHoldHandler.FetchShoppingRecord)
 	houseHold.POST("/:householdID/shopping/record", deps.HouseHoldHandler.CreateShoppingRecord)
+	houseHold.PUT("/:householdID/shopping/record/:shoppingID", deps.HouseHoldHandler.UpdateShoppingRecord)
 	houseHold.DELETE("/:householdID/shopping/record/:shoppingID", deps.HouseHoldHandler.RemoveShoppingRecord)
 
 	// LINE認証関連のエンドポイント

--- a/internal/domain/model/shopping.go
+++ b/internal/domain/model/shopping.go
@@ -153,6 +153,7 @@ type ShoppingRepository interface {
 	FetchShoppingMemoItem(householdID HouseHoldID) ([]*ShoppingMemo, error)
 	DeleteShoppingMemo(id ShoppingID) error
 	RegisterShoppingAmount(shopping *models.ShoppingAmount) error
+	UpdateShoppingAmount(shopping *models.ShoppingAmount) error
 	FetchShoppingAmountItemByHouseholdID(householdID HouseHoldID, date string) ([]*models.ShoppingAmount, error)
 	DeleteShoppingAmount(id ShoppingID) error
 }

--- a/internal/domain/service/house_hold_service.go
+++ b/internal/domain/service/house_hold_service.go
@@ -14,6 +14,7 @@ type HouseHoldService interface {
 	AddUserHouseHold(houseHold *domainmodel.HouseHold) error
 	AddHouseHoldCategory(houseHoldID domainmodel.HouseHoldID, categoryName string, categoryLimitAmount int) error
 	CreateShoppingAmount(shoppingAmount *domainmodel.ShoppingAmount) error
+	UpdateShoppingAmount(shoppingAmount *domainmodel.ShoppingAmount) error
 	RemoveShoppingAmount(shoppingAmountID domainmodel.ShoppingID) error
 	SummarizeShoppingAmount(input FetchShoppingRecordInput) (*domainmodel.SummarizeShoppingAmounts, error)
 }
@@ -102,6 +103,23 @@ func (h *houseHoldService) CreateShoppingAmount(shoppingAmount *domainmodel.Shop
 	}
 
 	return h.shoppingRepository.RegisterShoppingAmount(model)
+}
+
+// UpdateShoppingAmount implements HouseHoldService.
+func (h *houseHoldService) UpdateShoppingAmount(shoppingAmount *domainmodel.ShoppingAmount) error {
+	date, err := time.Parse("2006-01-02", shoppingAmount.Date)
+	if err != nil {
+		return errors.New("domainservice::UpdateShoppingAmount failed to parse date")
+	}
+	model := &models.ShoppingAmount{
+		Base:            models.Base{ID: uint(shoppingAmount.ID)},
+		CategoryID:      uint(shoppingAmount.CategoryID),
+		Amount:          shoppingAmount.Amount,
+		Date:            date,
+		Memo:            shoppingAmount.Memo,
+	}
+
+	return h.shoppingRepository.UpdateShoppingAmount(model)
 }
 
 // FetchShoppingAmount implements HouseHoldService.

--- a/internal/infrastructure/persistence/repository/shopping_repository.go
+++ b/internal/infrastructure/persistence/repository/shopping_repository.go
@@ -98,6 +98,19 @@ func (s *shoppingRepository) RegisterShoppingAmount(shopping *models.ShoppingAmo
 	return nil
 }
 
+// UpdateShoppingAmount implements domainmodel.ShoppingRepository.
+func (s *shoppingRepository) UpdateShoppingAmount(shopping *models.ShoppingAmount) error {
+	if err := s.db.Model(shopping).Updates(map[string]interface{}{
+		"category_id": shopping.CategoryID,
+		"amount":      shopping.Amount,
+		"date":        shopping.Date,
+		"memo":        shopping.Memo,
+	}).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
 // RegisterShoppingMemo implements domainmodel.ShoppingRepository.
 func (s *shoppingRepository) RegisterShoppingMemo(shopping *domainmodel.ShoppingMemo) error {
 	model := models.ShoppingMemo{

--- a/openapi.yml
+++ b/openapi.yml
@@ -352,6 +352,50 @@ paths:
         default:
           $ref: '#/components/responses/GeneralError'
   /household/{householdID}/shopping/record/{shoppingID}:
+    put:
+      tags:
+        - 買い物記録
+      summary: 買い物記録更新
+      description: 買い物記録を更新する
+      parameters:
+        - name: householdID
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: shoppingID
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                categoryID:
+                  type: integer
+                amount:
+                  type: integer
+                date:
+                  type: string
+                  format: date
+                memo:
+                  type: string
+              required:
+                - categoryID
+                - amount
+                - date
+      responses:
+        200:
+          description: OK
+        401:
+          $ref: '#/components/responses/UnauthorizedError'
+        404:
+          $ref: '#/components/responses/NotFoundError'
+        default:
+          $ref: '#/components/responses/GeneralError'
     delete:
       tags:
         - 買い物記録


### PR DESCRIPTION
## Summary
- PUT /household/{householdID}/shopping/record/{shoppingID} エンドポイントを追加
- 支出記録の金額・カテゴリ・日付・メモの更新機能を実装
- OpenAPI仕様書を更新

## 主な変更点
- `UpdateShoppingRecordRequest` 構造体を追加
- `UpdateShoppingRecord` ハンドラーを実装
- `UpdateShoppingAmount` サービス・リポジトリメソッドを追加
- CORSでPUTメソッドを許可
- OpenAPI仕様にPUTエンドポイントの定義を追加

## Test plan
- [ ] 支出記録の更新APIが正常に動作することを確認
- [ ] 無効なパラメータでエラーハンドリングが適切に動作することを確認
- [ ] フロントエンドとの連携テストを実施

関連Issue: #41

🤖 Generated with [Claude Code](https://claude.ai/code)